### PR TITLE
Add requirements.txt to make installing deps easy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,8 @@ Combined with a few python scripts, J.A.R.V.I.S now performs quite a few tasks:
 
 ## Requirements:
 
+You can run `pip install -r requirements.txt` to install them all.
+
 - ### AIML (For Pattern Recognition)
     `pip install aiml`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+aiml
+SpeechRecognition
+pyalsaaudio
+pyttsx
+gTTS


### PR DESCRIPTION
The pygame installation needs some fixing, especially for virtualenvs.
For eg. `sudo apt-get build-deps python-pygame` is no use without installing the
dependencies after that, and is also throwing error on my machine.

Anyway a `requirements.txt` is pretty standard way to maintain python dependencies